### PR TITLE
Use Forwardable#def_delegators for cleaner code

### DIFF
--- a/lib/dice/die_set.rb
+++ b/lib/dice/die_set.rb
@@ -1,7 +1,12 @@
+require 'forwardable'
+
 class DieSet
   attr_reader :dice
 
   include Enumerable
+  extend Forwardable
+
+  def_delegators :@dice, :each, :[]
 
   def initialize(dice)
     @dice = dice
@@ -11,13 +16,5 @@ class DieSet
     @dice.collect do |die|
       die.roll
     end
-  end
-
-  def each(&block)
-    @dice.each(&block)
-  end
-
-  def [](index)
-    @dice[index]
   end
 end


### PR DESCRIPTION
This makes the code more readable. The existing specs already cover this
behavior quite well.