### PR TITLE
Use Integer instead of Fixnum

### DIFF
--- a/lib/dice/die.rb
+++ b/lib/dice/die.rb
@@ -8,7 +8,7 @@ class Die
   def sides=(sides)
     if sides.respond_to? :to_a
       @sides = sides.to_a
-    elsif sides.is_a? Fixnum
+    elsif sides.is_a? Integer
       @sides = (1..sides).to_a
     else
       raise TypeError, "Cannot convert '#{sides.class}' to 'Array'"

--- a/lib/dice/extensions.rb
+++ b/lib/dice/extensions.rb
@@ -1,4 +1,4 @@
-class Fixnum
+class Integer
   def dice(sides=nil)
     DieSet.new(self.times.collect { Die.new(sides) })
   end


### PR DESCRIPTION
Fixnum has been deprecated in 2.4.0 (https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released).